### PR TITLE
fix: missing fallback translation when no locale available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
-import { readFileSync } from 'fs';
+import { readFileSync, readdirSync } from 'fs';
 import { resolve } from 'path';
 
 export function conventionalCommitsTypes(locale?: string) {
-  const fileName = locale ? `${locale}.json` : 'en.json';
+  const localizationFiles = readdirSync(resolve(__dirname, `../locale/`));
+  const fileName =
+    locale && localizationFiles.includes(`${locale}.json`) ? `${locale}.json` : 'en.json';
   return JSON.parse(readFileSync(resolve(__dirname, `../locale/${fileName}`), 'utf8'));
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -5,6 +5,7 @@ import { conventionalCommitsTypes } from '../src/index';
 describe('conventionalCommitsTypes() function test', () => {
   it.each([
     ['en.json', undefined],
+    ['en.json', 'unknown-locale'],
     ['en.json', 'en'],
     ['zh-cn.json', 'zh-cn']
   ])("should return content of %s when input is '%s'", (fileName, locale) => {


### PR DESCRIPTION
Hi dev,
today i discovered the existence of this translation package for conventional-commit-types with an exception from my Vistual Studio Code installation.

This PR should fix this bug by providing english as fallback localization when a there is no specific localization.